### PR TITLE
🔧 Efficient describe

### DIFF
--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -11,3 +11,29 @@ def test_that_describe_returns_expected_dictionary_for_df() -> None:
     assert 0.332 < actual["null_percentage_b"] < 0.334
     assert actual["length"] == 3
     assert actual["columns"] == "a_^&^_b"
+
+
+def test_that_describe_excludes_non_specified_columns() -> None:
+    df = pl.DataFrame({"a": [1.2, 1.3, 1.4], "b": ["one", "two", None]})
+    actual = dataframe.describe(df, columns=["a"])
+    assert "mean_a" in actual
+    assert "mean_b" not in actual
+
+
+def test_that_describe_excludes_non_specified_metrics() -> None:
+    df = pl.DataFrame({"a": [1.2, 1.3, 1.4], "b": ["one", "two", None]})
+    actual = dataframe.describe(df, metrics=["mean", "max"])
+    assert "mean_a" in actual
+    assert "mean_b" in actual
+    assert "max_a" in actual
+    assert "max_b" in actual
+    assert "std_a" not in actual
+    assert "std_b" not in actual
+
+
+def test_that_describe_excludes_non_specified_column_and_metric_combos() -> None:
+    df = pl.DataFrame({"a": [1.2, 1.3, 1.4], "b": ["one", "two", None]})
+    actual = dataframe.describe(df, columns=["a"], metrics=["count"])
+    assert "count_a" in actual
+    assert "count_b" not in actual
+    assert "min_a" not in actual

--- a/tests/test_executions.py
+++ b/tests/test_executions.py
@@ -1,0 +1,17 @@
+import polars as pl
+
+from wimsey import execution
+from wimsey import tests
+
+
+def test_run_all_tests_produces_expected_result_object():
+    tests_to_carry_out = [
+        tests.max_should(column="a", be_less_than=10),
+        tests.std_should(column="a", be_greated_than=0),
+        tests.type_should(column="b", be_one_of=["string", "int64"]),
+    ]
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["hat", "bat", "cat"]})
+    actual = execution.run_all_tests(df, tests_to_carry_out)
+    assert actual.success is True
+    for result in actual.results:
+        assert result.success is True

--- a/wimsey/dataframe.py
+++ b/wimsey/dataframe.py
@@ -3,7 +3,11 @@ from narwhals.stable.v1.typing import FrameT
 
 
 @nw.narwhalify
-def describe(df: FrameT) -> dict[str, float]:
+def describe(
+    df: FrameT,
+    columns: list[str] | None = None,
+    metrics: list[str] | None = None,
+) -> dict[str, float]:
     """
     Outputs a dictionary for use in testing, mimicking polars 'describe' method.
 
@@ -11,46 +15,69 @@ def describe(df: FrameT) -> dict[str, float]:
     """
     if not df.columns:
         return {}
+    columns = columns or df.columns
+    columns_to_check = [i for i in columns if i in df.columns]
+    metrics = metrics or [
+        "mean",
+        "std",
+        "min",
+        "max",
+        "type",
+        "count",
+        "null",
+        "length",
+    ]
 
     # Determine which columns should get std/mean/percentile statistics
     stat_cols = {c for c, dt in df.schema.items() if dt.is_numeric()}
 
-    required_exprs: list = []
-    post_exprs: list = []
-    required_exprs += [
-        (nw.col(c).mean() if c in stat_cols else nw.lit(None)).alias(f"mean_{c}")
-        for c in df.columns
-    ]
-    required_exprs += [
-        (nw.col(c).std() if c in stat_cols else nw.lit(None)).alias(f"std_{c}")
-        for c in df.columns
-    ]
-    required_exprs += [
-        (nw.col(c).min() if c in stat_cols else nw.lit(None)).alias(f"min_{c}")
-        for c in df.columns
-    ]
-    required_exprs += [
-        (nw.col(c).max() if c in stat_cols else nw.lit(None)).alias(f"max_{c}")
-        for c in df.columns
-    ]
-    required_exprs += [nw.lit(str(df.schema[c])).alias(f"type_{c}") for c in df.columns]
-    required_exprs += [
+    required_exprs: list = [
         nw.lit("_^&^_".join(df.columns)).alias("columns"),
-        nw.col(*df.columns).count().name.prefix("count_"),
-        nw.col(*df.columns).null_count().name.prefix("null_count_"),
     ]
-    post_exprs += [
-        (
-            nw.col(f"null_count_{c}")
-            / (nw.col(f"count_{c}") + nw.col(f"null_count_{c}"))
-        ).alias(f"null_percentage_{c}")
-        for c in df.columns
-    ]
-    post_exprs += [
-        (
-            nw.col(f"count_{df.columns[0]}") + nw.col(f"null_count_{df.columns[0]}")
-        ).alias("length")
-    ]
+    post_exprs: list = []
+    if "mean" in metrics:
+        required_exprs += [
+            (nw.col(c).mean() if c in stat_cols else nw.lit(None)).alias(f"mean_{c}")
+            for c in columns_to_check
+        ]
+    if "std" in metrics:
+        required_exprs += [
+            (nw.col(c).std() if c in stat_cols else nw.lit(None)).alias(f"std_{c}")
+            for c in columns_to_check
+        ]
+    if "min" in metrics:
+        required_exprs += [
+            (nw.col(c).min() if c in stat_cols else nw.lit(None)).alias(f"min_{c}")
+            for c in columns_to_check
+        ]
+    if "max" in metrics:
+        required_exprs += [
+            (nw.col(c).max() if c in stat_cols else nw.lit(None)).alias(f"max_{c}")
+            for c in columns_to_check
+        ]
+    if "type" in metrics:
+        required_exprs += [
+            nw.lit(str(df.schema[c])).alias(f"type_{c}") for c in columns_to_check
+        ]
+    if "count" in metrics or "null" in metrics or "leghth" in metrics:
+        required_exprs += [nw.col(*columns_to_check).count().name.prefix("count_")]
+    if "null" in metrics or "length" in metrics:
+        required_exprs += [
+            nw.col(*columns_to_check).null_count().name.prefix("null_count_")
+        ]
+        post_exprs += [
+            (
+                nw.col(f"null_count_{c}")
+                / (nw.col(f"count_{c}") + nw.col(f"null_count_{c}"))
+            ).alias(f"null_percentage_{c}")
+            for c in columns_to_check
+        ]
+        post_exprs += [
+            (
+                nw.col(f"count_{columns_to_check[0]}")
+                + nw.col(f"null_count_{columns_to_check[0]}")
+            ).alias("length")
+        ]
     df_metrics = df.select(
         *required_exprs,
     ).with_columns(*post_exprs)

--- a/wimsey/execution.py
+++ b/wimsey/execution.py
@@ -19,7 +19,21 @@ class DataValidationException(Exception):
 
 
 def run_all_tests(df: FrameT, tests: list[Callable[[Any], result]]) -> final_result:
-    description: dict[str, Any] = describe(df)
+    columns: set[str] | None = set()
+    metrics: set[str] | None = set()
+    for test in tests:
+        try:
+            metrics |= test.required_metrics
+            columns |= {test.keywords.get("column")} or set()
+        except AttributeError:
+            columns = None  # fall back to calculating everything
+            metrics = None
+            break
+    description: dict[str, Any] = describe(
+        df,
+        columns=list(columns),
+        metrics=list(metrics),
+    )
     results: list[result] = []
     for i_test in tests:
         results.append(i_test(description))


### PR DESCRIPTION
Resolves #8 

This introduces a little bit of wierdness (attaching a 'required_metrics' attribute to function partials) but should allow more efficient use of describe.

With this merged, *only* relevant columns and metrics will be calculated (so if you're not testing for maximum values, we won't calculate any, and if you're not testing "column-a", we won't calculate any metrics for that).

Note that there's still some room for improvement, for simplicity I've written things to calculate all combinations of metrics and columns (so if you're testing just the `std` of `column_a` and the `null_percentage` of `column_b`, wimsey will *still* calculate the `null_percentage` of `column_a` and the `std` of `column_b`.

I think it's an ok trade off, especially while things are still changing rapidly, to increase the simplicity of the codebase at the additional burden of performance. Either way, this should still be a big performance bump of the previous method.

Extra-extra note! I've added in this to the metrics/column collection:

```python
    for test in tests:
        try:
            metrics |= test.required_metrics
            columns |= {test.keywords.get("column")} or set()
        except AttributeError:
            columns = None  # fall back to calculating everything
            metrics = None
            break
```

This is because the method for determining metrics is a little wierd, there's a chance of causing chaos on someone who's unwittingly trying to extend wimsey, or write their own codes etc.

Rather than letting people shoot themselves in the foot, if tests don't broadcast what metrics they need, we'll fall back to less-performant correctness over crashing out completely.