### PR TITLE
🐛 Github pages deploy workflow fixed

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,7 +14,9 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements-dev.lock
-          git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git config pull.rebase false
           git pull origin main
           git pull origin gh-pages
           python -m mkdocs gh-deploy

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,8 +1,6 @@
 name: Deploy
-on:
-  push:
-    branches:
-      - main
+on: workflow_dispatch
+
 jobs:
   build:
     name: Deploy docs to GitHub Pages

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,5 +14,5 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements-dev.lock
-          git config user.name 'github-actions[bot]' && config user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
           python -m mkdocs gh-deploy

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,13 +10,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Build
-        uses: Tiryoh/actions-mkdocs@v0
-        with:
-          mkdocs_version: 'latest'
-          configfile: 'mkdocs.yml'
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Build and Deploy
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements-dev.lock
+          git config user.name 'github-actions[bot]' && config user.email 'github-actions[bot]@users.noreply.github.com'
+          python -m mkdocs gh-deploy
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -17,6 +17,6 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git config pull.rebase false
-          git pull origin main
-          git pull origin gh-pages
+          git pull origin main --allow-unrelated-histories
+          git pull origin gh-pages --allow-unrelated-histories
           python -m mkdocs gh-deploy

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,6 +16,3 @@ jobs:
           pip install -r requirements-dev.lock
           git config user.name 'github-actions[bot]' && config user.email 'github-actions[bot]@users.noreply.github.com'
           python -m mkdocs gh-deploy
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v2
       - name: Build and Deploy
@@ -17,6 +19,4 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git config pull.rebase false
-          git pull origin main --allow-unrelated-histories
-          git pull origin gh-pages --allow-unrelated-histories
           python -m mkdocs gh-deploy

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,5 +1,8 @@
-name: Deploy
-on: workflow_dispatch
+name: Build Docs
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -12,7 +15,7 @@ jobs:
           fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v2
-      - name: Build and Deploy
+      - name: Build and Deploy Docs
         run: |
           pip install --upgrade pip
           pip install -r requirements-dev.lock

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,4 +15,6 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements-dev.lock
           git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git pull origin main
+          git pull origin gh-pages
           python -m mkdocs gh-deploy


### PR DESCRIPTION
Deploy currently fails because plugin isn't installed. Rather than fiddle around with the action I've just moved the mkdocs commands into "run" which seems to make things work.